### PR TITLE
Removing lastExplanation variable and fixing explanations stating with %.

### DIFF
--- a/src/main/java/main/failExplainer.java
+++ b/src/main/java/main/failExplainer.java
@@ -217,13 +217,13 @@ public class failExplainer {
     	 * Return the string that is built.
     	 * */
 		List<Integer> failExplainingList = failExplainer.findAnExplanation(nums);
-		lastExplanation = "";
+		//lastExplanation = "";
 		Iterator<Integer> it = failExplainingList.iterator();
 		while (it.hasNext()) {
 			Integer arr = it.next();
-			String exp = InputOutputProcessor.restoreBackLinearLogicSide(str.get(arr)) + System.lineSeparator();
+			String exp = "% " + InputOutputProcessor.restoreBackLinearLogicSide(str.get(arr)) + System.lineSeparator();
 			explanationString.append(exp);
-			lastExplanation += "% " + exp;
+			//lastExplanation += "% " + exp;
 		}
 		return explanationString.toString();
     }

--- a/src/main/java/main/failExplainer.java
+++ b/src/main/java/main/failExplainer.java
@@ -22,8 +22,7 @@ public class failExplainer {
 	        return b.value - a.value;
 	    }
 	}
-	private static String lastExplanation="";
-	public static String getLastExplanation() {return lastExplanation;};
+
 	private static boolean intersects(boolean []indices, int[] nums) {
 		/*
 		 * This function checks if coverage nums intersects with the indices 

--- a/src/main/java/main/failExplainer.java
+++ b/src/main/java/main/failExplainer.java
@@ -216,13 +216,12 @@ public class failExplainer {
     	 * Return the string that is built.
     	 * */
 		List<Integer> failExplainingList = failExplainer.findAnExplanation(nums);
-		//lastExplanation = "";
+
 		Iterator<Integer> it = failExplainingList.iterator();
 		while (it.hasNext()) {
 			Integer arr = it.next();
 			String exp = "% " + InputOutputProcessor.restoreBackLinearLogicSide(str.get(arr)) + System.lineSeparator();
 			explanationString.append(exp);
-			//lastExplanation += "% " + exp;
 		}
 		return explanationString.toString();
     }


### PR DESCRIPTION
A minor update in fail explainer. Before the whole merge operation, this functionality was working through the lastExplanation variable. However, this time, since the explanation is based on only the last state of atomic and non-atomic charts, and the explain function is called for only this purpose, then this variable is not needed anymore. Also fixed explanations as comments starting with %.